### PR TITLE
enhance: use readonly field for username on mfa form

### DIFF
--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -57,7 +57,7 @@ body {
 
       <div>
          <label for="user_name">Username</label>
-         <input type="text" name="user_name" value="{{ username }}" readonly>
+         <input type="text" name="user_name" value="{{ username }}" readonly disabled>
       </div>
       <div class="has-required">
          <label for="mfa_token">Token</label>

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -55,8 +55,9 @@ body {
          </ul>
       {% endif %}
 
-      <div class="input-group">
-         Username: {{ username }}
+      <div>
+         <label for="user_name">Username</label>
+         <input type="text" name="user_name" value="{{ username }}" readonly>
       </div>
       <div class="has-required">
          <label for="mfa_token">Token</label>


### PR DESCRIPTION
## Overview

Make the Username data on the MFA form be in a read-only field.

## Related

- attempts to improve upon https://github.com/tapis-project/authenticator/commit/d30e96f

## Changes

- **replaces** text with label and readonly input

## Testing

1. Run system.
2. Login.
3. Visit MFA page.
4. Verify username field can not be edited.
5. Check whether Username label and field are legible.
6. Check whether Username label and field are similar in style to other field.
7. Verify form still works.

## UI

> **Warning**
> The containers are unable to be run on my system (my OS uses ARM architecture). So I test _in situ_ at https://cep.tacc.utexas.edu/static/ui/components/detail/s-form-page--login.html.

| Before | In Situ |
| - | - |
| <img width="359" alt="mfa before" src="https://github.com/tapis-project/authenticator/assets/62723358/90e78557-3338-4109-b0a9-a4ff2b619e02"> | ![mfa test in situ](https://github.com/tapis-project/authenticator/assets/62723358/6b08452e-05e3-44a7-aa1d-18d32664c08d) |