### PR TITLE
fix: right-align a solitary form button + tweak form title

### DIFF
--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -25,6 +25,11 @@ body {
           it covers the login form on screens shorter than the form */
   min-height: 100vh;
 }
+
+/* TODO: Integrate into TACC/Core-Styles s-form--login.css */
+.s-form--login :where(.s-form > footer) > :only-child {
+  margin-left: auto;
+}
 </style>
 {% endblock %}
 
@@ -46,7 +51,7 @@ body {
          {% include "./branding.html" %}
          {% endwith %}
          </figure>
-         <span>MFA Token</span>
+         <span>Enter MFA Token</span>
       </h1>
 
       {% if error %}

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -3,17 +3,17 @@
 
 {% block assets %}
 {{ super() }}
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/core-styles.settings.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/color--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/font--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/links.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/sticky-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form--login.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form-page.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer--thin.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/core-styles.settings.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/color--portal.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/font--portal.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/links.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/form.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/sticky-footer.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form--login.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form-page.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer--thin.css">
 {% endblock %}
 {% block head_extra %}
 <style>
@@ -24,11 +24,6 @@ body {
   /* FAQ: Replaces base.html fixed footer because it has a disadvantage—
           it covers the login form on screens shorter than the form */
   min-height: 100vh;
-}
-
-/* TODO: Integrate into TACC/Core-Styles s-form--login.css */
-.s-form--login :where(.s-form > footer) > :only-child {
-  margin-left: auto;
 }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Overview

By upgrading to Core-Styles v2.17.2, make a button alone in a form footer be aligned. Also, add "Enter" to form title.

## Related

- requires https://github.com/TACC/Core-Styles/pull/223

## Changes

- **changes** Core-Styles version to v.17.2 (to right-align solitary form footer button)
- **adds** enter to form title

## Testing

1. Open `https://…/v3/oauth2/mfa` (or otherwise get to the MFA form).
2. Verify "Submit" button is right-aligned.

## UI

> **Warning**
> The containers are unable to be run on my system (my OS uses ARM architecture). So I test _in situ_ at https://cep.tacc.utexas.edu/static/ui/components/detail/s-form-page--login.html.

| Before | In Situ |
| - | - |
| <img width="717" alt="mfa before" src="https://github.com/tapis-project/authenticator/assets/62723358/11666a85-227c-430d-88e5-baa5f8e91693"> | ![core-styles in situ test of same style](https://github.com/tapis-project/authenticator/assets/62723358/73f9f297-36e3-45a4-b14c-2a2d2be65c38) |