### PR TITLE
refactor: share auth form code in one template

### DIFF
--- a/service/templates/authorize.html
+++ b/service/templates/authorize.html
@@ -1,35 +1,4 @@
-{% extends 'base.html' %}
-
-{% block assets %}
-{{ super() }}
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/core-styles.settings.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/color--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/font--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/links.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/sticky-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form--login.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form-page.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer--thin.css">
-{% endblock %}
-{% block head_extra %}
-<style>
-body {
-  background-color: var(--global-color-primary--light);
-
-  /* So body is as tall as page, thus sticky footer sticks to bottom of page */
-  /* FAQ: Replaces base.html fixed footer because it has a disadvantage—
-          it covers the login form on screens shorter than the form */
-  min-height: 100vh;
-}
-</style>
-{% endblock %}
-
-{# So banner is NOT rendered #}
-{% block banner %}
-{% endblock %}
+{% extends 'base-auth.html' %}
 
 {% block content %}
 <body>
@@ -68,20 +37,4 @@ body {
      </footer>
   </form>
 </main>
-{% endblock %}
-
-{% block footer %}
-<footer class="s-footer">
-  <p>Tapis project funded by NSF OAC grants
-    <a
-      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931439"
-      rel="noreferrer"
-      target="_blank">#1931439</a>,
-    <a
-      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931575"
-      rel="noreferrer"
-      target="_blank">#1931575</a>
-    and #2232259.
-  </p>
-</footer>
 {% endblock %}

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+
+{% block assets %}
+{{ super() }}
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/core-styles.settings.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/color--portal.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/font--portal.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/links.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/form.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/sticky-footer.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form--login.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form-page.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer.css">
+<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer--thin.css">
+{% endblock %}
+
+{% block head_extra %}
+<style>
+body {
+  background-color: var(--global-color-primary--light);
+
+  /* So body is as tall as page, thus sticky footer sticks to bottom of page */
+  /* FAQ: Replaces base.html fixed footer because it has a disadvantage—
+          it covers the login form on screens shorter than the form */
+  min-height: 100vh;
+}
+</style>
+{% endblock %}
+
+{# So banner is NOT rendered #}
+{% block banner %}
+{% endblock %}
+
+{% block footer %}
+<footer class="s-footer">
+  <p>Tapis project funded by NSF OAC grants
+    <a
+      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931439"
+      rel="noreferrer"
+      target="_blank">#1931439</a>,
+    <a
+      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931575"
+      rel="noreferrer"
+      target="_blank">#1931575</a>
+    and #2232259.
+  </p>
+</footer>
+{% endblock %}

--- a/service/templates/login.html
+++ b/service/templates/login.html
@@ -1,35 +1,4 @@
-{% extends 'base.html' %}
-
-{% block assets %}
-{{ super() }}
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/core-styles.settings.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/color--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/font--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/links.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/sticky-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form--login.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form-page.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer--thin.css">
-{% endblock %}
-{% block head_extra %}
-<style>
-body {
-  background-color: var(--global-color-primary--light);
-
-  /* So body is as tall as page, thus sticky footer sticks to bottom of page */
-  /* FAQ: Replaces base.html fixed footer because it has a disadvantage—
-          it covers the login form on screens shorter than the form */
-  min-height: 100vh;
-}
-</style>
-{% endblock %}
-
-{# So banner is NOT rendered #}
-{% block banner %}
-{% endblock %}
+{% extends 'base-auth.html' %}
 
 {% block content %}
 <body>
@@ -97,20 +66,4 @@ body {
     </a>
   </footer>
 </main>
-{% endblock %}
-
-{% block footer %}
-<footer class="s-footer">
-  <p>Tapis project funded by NSF OAC grants
-    <a
-      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931439"
-      rel="noreferrer"
-      target="_blank">#1931439</a>,
-    <a
-      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931575"
-      rel="noreferrer"
-      target="_blank">#1931575</a>
-    and #2232259.
-  </p>
-</footer>
 {% endblock %}

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -1,36 +1,5 @@
 {% extends 'base-auth.html' %}
 
-{% block assets %}
-{{ super() }}
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/core-styles.settings.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/color--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/font--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/links.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/sticky-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form--login.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form-page.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer--thin.css">
-{% endblock %}
-{% block head_extra %}
-<style>
-body {
-  background-color: var(--global-color-primary--light);
-
-  /* So body is as tall as page, thus sticky footer sticks to bottom of page */
-  /* FAQ: Replaces base.html fixed footer because it has a disadvantage—
-          it covers the login form on screens shorter than the form */
-  min-height: 100vh;
-}
-</style>
-{% endblock %}
-
-{# So banner is NOT rendered #}
-{% block banner %}
-{% endblock %}
-
 {% block content %}
 <main class="s-form-page">
    <form action="" method="post" class="s-form s-form--login">

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -1,36 +1,4 @@
-{% extends 'base.html' %}
-
-
-{% block assets %}
-{{ super() }}
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/core-styles.settings.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/color--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/font--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/links.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/sticky-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form--login.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form-page.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer--thin.css">
-{% endblock %}
-{% block head_extra %}
-<style>
-body {
-  background-color: var(--global-color-primary--light);
-
-  /* So body is as tall as page, thus sticky footer sticks to bottom of page */
-  /* FAQ: Replaces base.html fixed footer because it has a disadvantage—
-          it covers the login form on screens shorter than the form */
-  min-height: 100vh;
-}
-</style>
-{% endblock %}
-
-{# So banner is NOT rendered #}
-{% block banner %}
-{% endblock %}
+{% extends 'base-auth.html' %}
 
 {% block content %}
 <body>
@@ -74,20 +42,4 @@ body {
       </footer>
    </form>
 </main>
-{% endblock %}
-
-{% block footer %}
-<footer class="s-footer">
-  <p>Tapis project funded by NSF OAC grants
-    <a
-      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931439"
-      rel="noreferrer"
-      target="_blank">#1931439</a>,
-    <a
-      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931575"
-      rel="noreferrer"
-      target="_blank">#1931575</a>
-    and #2232259.
-  </p>
-</footer>
 {% endblock %}

--- a/service/templates/select_idp.html
+++ b/service/templates/select_idp.html
@@ -1,35 +1,4 @@
-{% extends 'base.html' %}
-{% block assets %}
-{{ super() }}
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/core-styles.settings.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/color--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/settings/font--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/links.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/elements/sticky-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form--login.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-form-page.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.0/dist/trumps/s-footer--thin.css">
-{% endblock %}
-{% block head_extra %}
-<style>
-body {
-  background-color: var(--global-color-primary--light);
-
-  /* So body is as tall as page, thus sticky footer sticks to bottom of page */
-  /* FAQ: Replaces base.html fixed footer because it has a disadvantage—
-          it covers the login form on screens shorter than the form */
-  min-height: 100vh;
-}
-</style>
-{% endblock %}
-
-{# So banner is NOT rendered #}
-{% block banner %}
-{% endblock %}
-
+{% extends 'base-auth.html' %}
 
 {% block content %}
 <body>
@@ -85,20 +54,4 @@ body {
  </footer>
 
 </main>
-{% endblock %}
-
-{% block footer %}
-<footer class="s-footer">
-  <p>Tapis project funded by NSF OAC grants
-    <a
-      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931439"
-      rel="noreferrer"
-      target="_blank">#1931439</a>,
-    <a
-      href="https://www.nsf.gov/awardsearch/showAward?AWD_ID=1931575"
-      rel="noreferrer"
-      target="_blank">#1931575</a>
-    and #2232259.
-  </p>
-</footer>
 {% endblock %}


### PR DESCRIPTION
## Overview

Share all duplicate code for auth forms in one template that each now extends.

## Changes

- **added** `base-auth.html`
- **changed** all auth. forms to extend `base-auth.html`
- **removed** all auth. forms code that is now in `base-auth.html`

## Testing

Verify all these forms are still functional:
- authorize
- login
- mfa
- idp

## UI

> **Important**
> I cannot test this, because the containers are unable to be run on my system (my OS uses ARM architecture), and I have not requested a VM for TAPIS development.