### PR TITLE
fix: missing body tags, put in one template

### DIFF
--- a/service/templates/authorize.html
+++ b/service/templates/authorize.html
@@ -32,8 +32,6 @@ body {
 {% endblock %}
 
 {% block content %}
-<body>
-
 <main class="s-form-page">
   <form action="" method="post" class="s-form s-form--login">
     <h1> Tapis Authorization - Tenant {{ tenant_id }}</h1>

--- a/service/templates/base.html
+++ b/service/templates/base.html
@@ -90,6 +90,7 @@
 <!--}-->
 <!--</style>-->
 <!--</head>-->
+<body>
 
 {% block banner %}
   {% with tenant_id=tenant_id, is_banner=true %}
@@ -107,3 +108,5 @@
 </div>
 </footer>
 {% endblock %}
+
+</body>

--- a/service/templates/device-code.html
+++ b/service/templates/device-code.html
@@ -1,7 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<body>
-
  <div class="container">
     <h2> Device Activation </h2>
  </div>

--- a/service/templates/login.html
+++ b/service/templates/login.html
@@ -32,8 +32,6 @@ body {
 {% endblock %}
 
 {% block content %}
-<body>
-
 <main class="s-form-page">
   <form action="" method="post" class="s-form s-form--login">
     <h1>

--- a/service/templates/logout.html
+++ b/service/templates/logout.html
@@ -1,7 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<body>
-
  <div class="container">
     <h2> Tapis Logout </h2>
  </div>

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -33,8 +33,6 @@ body {
 {% endblock %}
 
 {% block content %}
-<body>
-
 <main class="s-form-page">
    <form action="" method="post" class="s-form s-form--login">
       <h1>

--- a/service/templates/select_idp.html
+++ b/service/templates/select_idp.html
@@ -32,8 +32,6 @@ body {
 
 
 {% block content %}
-<body>
-
 <main class="s-form-page">
  <form action="" method="post" class="s-form s-form--login">   
    <h1>

--- a/service/templates/success.html
+++ b/service/templates/success.html
@@ -1,11 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
-<body>
-
 <div class="container">
 <h2> Congrats! Device Code entered successfully. Please return to your application</h2>
 
 </div>
-
-</body>
 {% endblock %}

--- a/service/templates/tenant.html
+++ b/service/templates/tenant.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<body>
  <div class="container">
     <h2> Tapis Tenant </h2>
  </div>

--- a/service/templates/token-display.html
+++ b/service/templates/token-display.html
@@ -1,6 +1,5 @@
 {% extends 'base.html' %}
 {% block content %}
-<body>
  <div class="container">
     <h2> User Profile And Access Token</h2>
  </div>


### PR DESCRIPTION
## Overview

Several pages (re-designed with login form style) are missing closing body tag.

This fixes that by putting open and close body tag in one template.

## Related

- caused by https://github.com/tapis-project/authenticator/pull/36

## Testing

1. Open all affected pages.
2. Verify each has `<body>` (before all content) and `</body>` (after all content).

## UI

Skipped. I have not set up a test env. yet. Sorry.