### PR TITLE
fix: do not use Bootstrap class "form-control"

### DIFF
--- a/service/templates/device-code.html
+++ b/service/templates/device-code.html
@@ -55,7 +55,7 @@ body {
 
     <div class="has-required">
       <label for="user_code">User Code</label>
-      <input id="user_code" type="text" class="form-control" name="user_code" required>
+      <input id="user_code" type="text" name="user_code" required>
       <input type="hidden" name="client_id" value="{{ client_id }}">
       <input type="hidden" name="client_redirect_uri" value="{{ client_redirect_uri }}">
       <input type="hidden" name="client_display_name" value="{{ client_display_name }}">

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -27,7 +27,7 @@
       </div>
       <div class="has-required">
          <label for="mfa_token">Token</label>
-         <input id="mfa_token" type="text" class="form-control" name="mfa_token" placeholder="Enter MFA Token" required>
+         <input id="mfa_token" type="text" name="mfa_token" placeholder="Enter MFA Token" required>
          <input type="hidden" name="client_id" value="{{ client_id }}">
          <input type="hidden" name="client_redirect_uri" value="{{ client_redirect_uri }}">
          <input type="hidden" name="client_display_name" value="{{ client_display_name }}">


### PR DESCRIPTION
## Overview

To fix UI bug, remove Bootstrap class.

<details><summary>Why not use Bootstrap class?</summary>

Core-Styles is not 100% compatible with Bootstrap. Core Styles form styles are designed to replace Bootstrap's ([source](https://github.com/TACC/Core-Styles/blob/v2.17.2/docs/bootstrap.md)).

</details>

## Related

- included in #47

## Changes

- **removed** `form-control` class from markup

## Testing

The "User Code" and "Token" fields should now be the same width as other form fields, and have the same design when [in focus](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus).

## UI

## Device

| before | after |
| - | - |
| <img width="992" alt="device before fix" src="https://github.com/tapis-project/authenticator/assets/62723358/01176184-710b-4635-a869-76538999f317"> | <img width="992" alt="device after fix" src="https://github.com/tapis-project/authenticator/assets/62723358/879a40ab-292f-445c-ad8a-1e58996e24cc"> |

## M.F.A.

| before | after |
| - | - |
| <img width="992" alt="mfa before fix" src="https://github.com/tapis-project/authenticator/assets/62723358/552a7729-338f-478a-977e-8f737824f12c"> | <img width="992" alt="mfa after fix" src="https://github.com/tapis-project/authenticator/assets/62723358/5ea6b5bb-faab-4390-b3d5-f88b0c4d90c1"> |