### PR TITLE
fix: missing error styles need css layers

### DIFF
--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -2,17 +2,21 @@
 
 {% block assets %}
 {{ super() }}
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/core-styles.settings.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/color--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/font--portal.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/links.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/sticky-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form--login.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form-page.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer.css">
-<link rel="stylesheet" href="https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer--thin.css">
+<style>
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/core-styles.settings.css') layer(base);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/links.css') layer(base);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/form.css') layer(base);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/sticky-footer.css') layer(base);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form.css') layer(base);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form--login.css') layer(base);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form-page.css') layer(base);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer.css') layer(base);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer--thin.css') layer(base);
+
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form--portal.css') layer(project);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/color--portal.css') layer(project);
+  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/font--portal.css') layer(project);
+</style>
 {% endblock %}
 
 {% block head_extra %}

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -3,6 +3,7 @@
 {% block assets %}
 {{ super() }}
 <style>
+  /* base styles */
   @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/core-styles.settings.css') layer(base);
   @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/links.css') layer(base);
   @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/form.css') layer(base);
@@ -13,6 +14,7 @@
   @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer.css') layer(base);
   @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer--thin.css') layer(base);
 
+  /* portal (or cms) styles */
   @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form--portal.css') layer(project);
   @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/color--portal.css') layer(project);
   @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/font--portal.css') layer(project);

--- a/service/templates/base.html
+++ b/service/templates/base.html
@@ -6,7 +6,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% block assets %}
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.min.css">
+  <style>
+    @layer foundation, base, project;
+    @import url('https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.min.css') layer(foundation);
+  </style>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
   {% endblock %}

--- a/service/templates/device-code.html
+++ b/service/templates/device-code.html
@@ -55,7 +55,7 @@ body {
 
     <div class="has-required">
       <label for="user_code">User Code</label>
-      <input id="user_code" type="text" class="form-control" name="user_code" required>
+      <input id="user_code" type="text" name="user_code" required>
       <input type="hidden" name="client_id" value="{{ client_id }}">
       <input type="hidden" name="client_redirect_uri" value="{{ client_redirect_uri }}">
       <input type="hidden" name="client_display_name" value="{{ client_display_name }}">

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -27,7 +27,7 @@
       </div>
       <div class="has-required">
          <label for="mfa_token">Token</label>
-         <input id="mfa_token" type="text" class="form-control" name="mfa_token" placeholder="Enter MFA Token" required>
+         <input id="mfa_token" type="text" name="mfa_token" placeholder="Enter MFA Token" required>
          <input type="hidden" name="client_id" value="{{ client_id }}">
          <input type="hidden" name="client_redirect_uri" value="{{ client_redirect_uri }}">
          <input type="hidden" name="client_display_name" value="{{ client_display_name }}">


### PR DESCRIPTION
## Overview

1. Style error messages by loading Core-Styles `s-form--portal`.
2. Load styles in layers[^1] so `s-form--portal` can be in highest layer.
3. Remove two classes causing wrong styles ([#46](https://github.com/tapis-project/authenticator/pull/46)).

## Related

- includes #46

## Changes

- **changed** load of core-styles and bootstrap to be done in layers
- **added** load of core-styles `s-form--portal.css`
- **removed** `form-control` class

## Testing

Any forms that show errors (e.g. https://dev.develop.tapis.io/v3/oauth2/device) should not style those errors.

## UI

### Device

| before | after |
| - | - |
| <img width="992" alt="device - before" src="https://github.com/tapis-project/authenticator/assets/62723358/b3f0a08f-a764-4c6f-a3a9-e6f9fc377bbc"> | <img width="992" alt="device - after" src="https://github.com/tapis-project/authenticator/assets/62723358/dd893031-3c2f-414a-833c-3a2033efa13e"> |

What changed?
- errors are now styled
- input field is now not wider than form content should be
- input field style now does not have Bootstrap styles

<details><summary>In Situ Testing</summary>

| step 1 | step 2 | step 3 |
| - | - | - |
| <img width="992" alt="device - 1 remove form-control class" src="https://github.com/tapis-project/authenticator/assets/62723358/cd55e6ef-11b9-49a8-9fe2-19df69f45ed7"> | <img width="992" alt="device - 2 move bootstrap to foudnation layer" src="https://github.com/tapis-project/authenticator/assets/62723358/c91d41a8-115a-4c43-9f14-207431bf3f8c"> | <img width="992" alt="device - 3 move core-styles to base and project layers" src="https://github.com/tapis-project/authenticator/assets/62723358/311b634a-76e5-456e-8166-a1c67c579591"> |

</details>

### MFA

| before | after |
| - | - |
| <img width="992" alt="mfa - before" src="https://github.com/tapis-project/authenticator/assets/62723358/c3b17a99-514e-4b2c-875c-eab6224cc7f6"> | <img width="992" alt="mfa - after" src="https://github.com/tapis-project/authenticator/assets/62723358/d52b7f3a-0494-495d-82b5-75249f3ffff9"> |

What changed?
- input field is now not wider than form content should be
- input field style now does not have Bootstrap styles

<details><summary>In Situ Testing</summary>

| step 1 | step 2 | step 3 |
| - | - | - |
| <img width="992" alt="mfa - 1 remove form-control class" src="https://github.com/tapis-project/authenticator/assets/62723358/d8871b00-d5b1-4d7d-8e2f-55d58417a608"> | <img width="992" alt="mfa - 2 move bootstrap to foudnation layer" src="https://github.com/tapis-project/authenticator/assets/62723358/eb93f4ef-d33f-4915-a83e-190a9d0cf6db"> | <img width="992" alt="mfa - 3 move core-styles to base and project layers" src="https://github.com/tapis-project/authenticator/assets/62723358/51a696a3-8308-4bde-a154-b79d23fd0510"> |

</details>

## Notes

TACC uses[^1] CSS layers which are [widely supported](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer#browser_compatibility). They are used by https://github.com/TACC/tup-ui and newer https://github.com/TACC/Core-CMS-Custom. They will be used by https://github.com/TACC/Core-Portal.

[^1]: [TACC CSS Layers][tacc-css-layers]

[tacc-css-layers]: https://confluence.tacc.utexas.edu/x/b53tDg
