### PR TITLE
refactor: core-styles cdn url and ver. in one spot

### DIFF
--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -1,25 +1,27 @@
 {% extends 'base.html' %}
 
+{% with core_styles_cdn_url="https://unpkg.com/@tacc/core-styles@2.17.3" %}
 {% block assets %}
 {{ super() }}
 <style>
   /* base styles */
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/core-styles.settings.css') layer(base);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/links.css') layer(base);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/form.css') layer(base);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/elements/sticky-footer.css') layer(base);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form.css') layer(base);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form--login.css') layer(base);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form-page.css') layer(base);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer.css') layer(base);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-footer--thin.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/core-styles.settings.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/elements/links.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/elements/form.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/elements/sticky-footer.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/trumps/s-form.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/trumps/s-form--login.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/trumps/s-form-page.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/trumps/s-footer.css') layer(base);
+  @import url('{{ core_styles_cdn_url }}/dist/trumps/s-footer--thin.css') layer(base);
 
   /* portal (or cms) styles */
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/trumps/s-form--portal.css') layer(project);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/color--portal.css') layer(project);
-  @import url('https://unpkg.com/@tacc/core-styles@2.17.2/dist/settings/font--portal.css') layer(project);
+  @import url('{{ core_styles_cdn_url }}/dist/trumps/s-form--portal.css') layer(project);
+  @import url('{{ core_styles_cdn_url }}/dist/settings/color--portal.css') layer(project);
+  @import url('{{ core_styles_cdn_url }}/dist/settings/font--portal.css') layer(project);
 </style>
 {% endblock %}
+{% endwith %}
 
 {% block head_extra %}
 <style>

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% with core_styles_cdn_url="https://unpkg.com/@tacc/core-styles@2.17.3" %}
+{% with core_styles_cdn_url="https://unpkg.com/@tacc/core-styles@2.17.5" %}
 {% block assets %}
 {{ super() }}
 <style>


### PR DESCRIPTION
## Overview

- Reduce duplication and maintenance working with https://github.com/TACC/Core-Styles/.
- Update https://github.com/TACC/Core-Styles for patch fix.
    <sup>This is done in [#49](https://github.com/tapis-project/authenticator/pull/49), but using the tedious way.</sup>

## Related

- will conflict with #49

## Changes

1. Store the https://github.com/TACC/Core-Styles/ CDN URL and version in one variable.
2. Use that variable instead of repeating the URL.

## Testing

Verify all forms using https://github.com/TACC/Core-Styles/ look the same.

## UI

Skipped.