### PR TITLE
hotfix: select_idp and logout not loading custom styles

### DIFF
--- a/service/templates/logout.html
+++ b/service/templates/logout.html
@@ -29,7 +29,7 @@
 {% endblock %}
 
 {% block head_extra %}
-{{ super() }}
+{{ super.super() }}
 {% if not logout_message %}
   <style>
   /* To center the submit button */

--- a/service/templates/select_idp.html
+++ b/service/templates/select_idp.html
@@ -53,7 +53,7 @@
 {% endblock %}
 
 {% block head_extra %}
-{{ super() }}
+{{ super.super() }}
 <style>
   .button-list {
     /* To lay out buttons in a flexible centered column */


### PR DESCRIPTION
## Overview

Make `select_idp.html` and `logout.html` load their custom styles.

<details>

I used wrong super syntax. These pages are grandchildren inheritance.

https://jinja.palletsprojects.com/en/3.1.x/templates/#nesting-extends

</details>

## Changed

- **fixed** `super` syntax

## UI

| | Broken | Expected |
| - | - | - |
| `logout.html` | ![logout BEFORE](https://github.com/tapis-project/authenticator/assets/62723358/e678c362-ffab-49ac-8f00-a6d0746265e4) | ~~Logout button should be right-aligned, like in #53.~~ |
| `select_idp.html` | ![select_idp BEFORE](https://github.com/tapis-project/authenticator/assets/62723358/2472e905-2b59-41f2-be75-196f1736d8f6) | Buttons should… **not** a mess. See #54. |

