### PR TITLE
hotfix: idp form buttons are unstyled

### DIFF
--- a/service/templates/select_idp.html
+++ b/service/templates/select_idp.html
@@ -22,12 +22,14 @@
    </ul>
    {% endif %}
 
+     <div class="button-list">
         {% for idp in idps %}
         <button name="idp_id" value="{{ idp.idp_id }}" type="submit">
           <img src="authorize/{{ idp.idp_id }}.svg" alt="{{ idp.idp_name }}" />
           {{ idp.idp_name }}
         </button>
         {% endfor %}
+     </div>
      <nav>
       <p>Having trouble?</p>
       <a


### PR DESCRIPTION
## Overview

Apply `.button-list` styles to buttons on IDP form.

## Related

- fixes #54

## Changes

- **added** missing `<div class="button-list">` wrap around buttons

## Testing & UI

| before | after |
| - | - |
| ![before](https://github.com/tapis-project/authenticator/assets/62723358/e51caec8-2ab7-429f-aead-dce4db6832c1) | ![after](https://github.com/tapis-project/authenticator/assets/62723358/baf7f571-5ba9-4fad-b492-c61eb3075f45) |