### PR TITLE
enhance: link to tapis on authorize form

### DIFF
--- a/service/templates/authorize.html
+++ b/service/templates/authorize.html
@@ -14,7 +14,7 @@
       </figure>
       <span>Connect to Tapis</span>
     </h1>
-    <p>The <var>{{ client_display_name }}</var> wants to use Tapis (TACC APIs) service to enable actions on behalf of <var>{{ username }}</var>.</p>
+    <p>The <var>{{ client_display_name }}</var> wants to use <a href="https://tapis-project.org/" target="_blank">Tapis</a> (TACC APIs) service to grant actions on behalf of <var>{{ username }}</var>.</p>
 
     {% if error %}
     <ul>


### PR DESCRIPTION
## Overview

Link "Tapis" to to https://tapis-project.org/. [^1]

## Related

- includes #58

## Testing

1. Open auth form.
2. Verify text is a link to https://tapis-project.org/.
3. Verify link opens in new window/tab.

[^1]: [Why? Promote Tapis. (internal link)](https://tacc-team.slack.com/archives/C05UDEE99M5/p1696286474409529?thread_ts=1696286330.155879&cid=C05UDEE99M5)