### PR TITLE
enhance: WP-308 form footer "Powered by: [tapis]"

### DIFF
--- a/service/templates/authorize.html
+++ b/service/templates/authorize.html
@@ -44,15 +44,7 @@
       <button type="submit" name="approve" value="true" required>Connect</button>
     </footer>
   </form>
-  <footer>
-    <a href="https://tacc.utexas.edu/about/security-and-compliance/">
-      Security
-    </a>
-    <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
-      Policies
-    </a>
-    {% include "./powered_by.html" %}
-  </footer>
+  {% include "./content_footer.html" %}
 </main>
 {% endblock %}
 

--- a/service/templates/authorize.html
+++ b/service/templates/authorize.html
@@ -44,6 +44,15 @@
       <button type="submit" name="approve" value="true" required>Connect</button>
     </footer>
   </form>
+  <footer>
+    <a href="https://tacc.utexas.edu/about/security-and-compliance/">
+      Security
+    </a>
+    <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
+      Policies
+    </a>
+    {% include "./powered_by.html" %}
+  </footer>
 </main>
 {% endblock %}
 

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -3,7 +3,7 @@
 {% block assets %}
 {{ super() }}
 
-{% with core_styles_cdn_url="https://unpkg.com/@tacc/core-styles@2.17.5" %}
+{% with core_styles_cdn_url="https://unpkg.com/@tacc/core-styles@2.18.0" %}
 <style>
   /* base styles */
   @import url('{{ core_styles_cdn_url }}/dist/core-styles.settings.css') layer(base);

--- a/service/templates/content_footer.html
+++ b/service/templates/content_footer.html
@@ -1,0 +1,13 @@
+<footer>
+  <a href="https://tacc.utexas.edu/about/security-and-compliance/">
+    Security
+  </a>
+  <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
+    Policies
+  </a>
+  <a href="https://tapis-project.org" target="_blank" class="powered_by">
+    Powered by:
+    <img src="https://dev.develop.tapis.io/v3/oauth2/authorize/tapis.png"
+      alt="Tapis logo" title="Tapis (TACC APIs)" height="50px">
+  </a>
+</footer>

--- a/service/templates/content_footer.html
+++ b/service/templates/content_footer.html
@@ -11,3 +11,13 @@
       alt="Tapis logo" title="Tapis (TACC APIs)" height="50px">
   </a>
 </footer>
+
+{% block head_extra %}
+{{ super() }}
+<style>
+  /* To move non-image links to the left */
+  .powered_by {
+    margin-left: auto;
+  }
+</style>
+{% endblock %}

--- a/service/templates/device-code.html
+++ b/service/templates/device-code.html
@@ -35,14 +35,6 @@
       <button type="submit">Submit</button>
     </footer>
   </form>
-  <footer>
-    <a href="https://tacc.utexas.edu/about/security-and-compliance/">
-      Security
-    </a>
-    <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
-      Policies
-    </a>
-    {% include "./powered_by.html" %}
-  </footer>
+  {% include "./content_footer.html" %}
 </main>
 {% endblock %}

--- a/service/templates/device-code.html
+++ b/service/templates/device-code.html
@@ -35,5 +35,14 @@
       <button type="submit">Submit</button>
     </footer>
   </form>
+  <footer>
+    <a href="https://tacc.utexas.edu/about/security-and-compliance/">
+      Security
+    </a>
+    <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
+      Policies
+    </a>
+    {% include "./powered_by.html" %}
+  </footer>
 </main>
 {% endblock %}

--- a/service/templates/login.html
+++ b/service/templates/login.html
@@ -55,15 +55,7 @@
       </a>
     </nav>
   </form>
-  <footer>
-    <a href="https://tacc.utexas.edu/about/security-and-compliance/">
-      Security
-    </a>
-    <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
-      Policies
-    </a>
-    {% include "./powered_by.html" %}
-  </footer>
+  {% include "./content_footer.html" %}
 </main>
 {% endblock %}
 

--- a/service/templates/login.html
+++ b/service/templates/login.html
@@ -62,6 +62,7 @@
     <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
       Policies
     </a>
+    {% include "./powered_by.html" %}
   </footer>
 </main>
 {% endblock %}

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -40,5 +40,14 @@
          <button type="submit">Submit</button>
       </footer>
    </form>
+   <footer>
+      <a href="https://tacc.utexas.edu/about/security-and-compliance/">
+         Security
+      </a>
+      <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
+         Policies
+      </a>
+      {% include "./powered_by.html" %}
+   </footer>
 </main>
 {% endblock %}

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -40,14 +40,6 @@
          <button type="submit">Submit</button>
       </footer>
    </form>
-   <footer>
-      <a href="https://tacc.utexas.edu/about/security-and-compliance/">
-         Security
-      </a>
-      <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
-         Policies
-      </a>
-      {% include "./powered_by.html" %}
-   </footer>
+  {% include "./content_footer.html" %}
 </main>
 {% endblock %}

--- a/service/templates/powered_by.html
+++ b/service/templates/powered_by.html
@@ -1,0 +1,5 @@
+<a href="https://tapis-project.org" target="_blank">
+  Powered by:
+  <img src="https://dev.develop.tapis.io/v3/oauth2/authorize/tapis.png"
+    alt="Tapis logo" title="Tapis (TACC APIs)" height="50px">
+</a>

--- a/service/templates/powered_by.html
+++ b/service/templates/powered_by.html
@@ -1,5 +1,0 @@
-<a href="https://tapis-project.org" target="_blank">
-  Powered by:
-  <img src="https://dev.develop.tapis.io/v3/oauth2/authorize/tapis.png"
-    alt="Tapis logo" title="Tapis (TACC APIs)" height="50px">
-</a>

--- a/service/templates/select_idp.html
+++ b/service/templates/select_idp.html
@@ -42,15 +42,7 @@
     </nav>
 
  </form>
- <footer>
-   <a href="https://tacc.utexas.edu/about/security-and-compliance/">
-     Security
-   </a>
-   <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
-     Policies
-   </a>
-   {% include "./powered_by.html" %}
- </footer>
+  {% include "./content_footer.html" %}
 
 </main>
 {% endblock %}

--- a/service/templates/select_idp.html
+++ b/service/templates/select_idp.html
@@ -49,6 +49,7 @@
    <a href="https://tacc.utexas.edu/use-tacc/user-policies/">
      Policies
    </a>
+   {% include "./powered_by.html" %}
  </footer>
 
 </main>


### PR DESCRIPTION
## Overview

Add "Powered by: [tapis]" to form footer. Update Core-Styles version.

## Related

- [WP-308](https://jira.tacc.utexas.edu/browse/WP-308)
- requires https://github.com/TACC/Core-Styles/pull/240
- reverted by #61
- replaced by #62

## Changes

- **added** form footer template
- **added** form footer to forms that had none
- **added** "Powered by: [tapis]" to all redesigned forms
- **changed** Core-Styles version

## Testing

1. All redesigned forms should have these beneath form:
	- "Security" and "Policy" (left-aligned)
	- "Powered by: [Tapis]" (right-aligned)
2. Hover over "Powered by:" should only underline that text.
	- **not** space before nor after
	- **not** the image

## UI

| idp | login | authorize | mfa |
| - | - | - | - |
| ![login](https://github.com/tapis-project/authenticator/assets/62723358/1d0b9648-c3fd-48b9-8ec7-d8a90dab13d4) | ![idp](https://github.com/tapis-project/authenticator/assets/62723358/956ba856-95ef-40bb-a802-7934fc988e5f) | ![authorize](https://github.com/tapis-project/authenticator/assets/62723358/4c871388-52a5-4988-99f7-9a114ff98c57) | ![mfa](https://github.com/tapis-project/authenticator/assets/62723358/20d25f86-614c-4de5-82f4-045c0936448f) |

| "Powered by:" link on hover |
| - |
| ![_hover](https://github.com/tapis-project/authenticator/assets/62723358/8ae31252-bc0a-4167-b557-82cfa4774852) |

> **Note**
> I cannot render every form, because I test _in situ_.