### PR TITLE
feat: support API_NAME via .env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 ifndef API_NAME
 -include .env
 endif
-api := $(API_NAME)
+api=$(API_NAME)
 
 cwd=$(shell pwd)
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 ifndef API_NAME
 -include .env
 endif
-api=$(API_NAME)
+api=${API_NAME}
 
 cwd=$(shell pwd)
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@
 
 
 # it is required that the operator export API_NAME=<name_of_the_api> before using this makefile/
-api=${API_NAME}
+-include .env
+ifdef API_NAME
+	api := $(API_NAME)
+endif
 
 cwd=$(shell pwd)
 

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@
 
 
 # it is required that the operator export API_NAME=<name_of_the_api> before using this makefile/
+ifndef API_NAME
 -include .env
-ifdef API_NAME
-	api := $(API_NAME)
 endif
+api := $(API_NAME)
 
 cwd=$(shell pwd)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ be sure to run:
 $ export API_NAME=authenticator
 ```
 
+Alternatively, create a `.env` file with the content `API_NAME=authenticator`.
+
 The `API_NAME` variable is used to let the `make` system know which Tapis service to work with.
 
 


### PR DESCRIPTION
## Overview

Do not force operator to remember `export API_NAME=authenticator` command.

Read a `.env` file if it is available.

## Changed

- **changed** `Makefile` to export from `.env` (if available)
- **changed** `README.md` to offer `.env` alternative to export

## Testing

Verify `Makefile` supports `export` and `.env` for `API_NAME`, in that order.

<details>

1. Clone/Open repo.
2. Do **not** run `export API_NAME=authenticator` command.
3. Run `make init_dbs`.
4. Verify **error** occurs (indirectly) because of missing API_NAME.
5. Create an `.env` file with content `export API_NAME=bob`.
6. Run `make init_dbs`.
7. Verify output uses `API_NAME` of **"bob"**.
8. Run `export API_NAME=authenticator`.
9. Run `make init_dbs`.
10. Verify output uses `API_NAME` of **"authenticator"**.

</details>

## Notes

I read that the "make system is generic and used by multiple Tapis services".

Where is the source of truth for this generic Makefile?