### PR TITLE
fix: GH-74 docker compose v2 unsupported

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean: down
 
 # ----- start databases
 run_dbs: build.api down
-	cd $(cwd); docker-compose up -d postgres; docker-compose up -d authenticator-ldap
+	cd $(cwd); docker-compose --compatibility up -d postgres; docker-compose up -d authenticator-ldap
 
 # ----- connect to db as root
 connect_db:


### PR DESCRIPTION
## Overview

Support Docker Compose v2 by adding `--compatibility` flag for v1 dependency.

## Related

- fixes #74

## Testing

<details open><summary>

### Quick Way

</summary>

1. Have environment with Docker Compose v1.
2. Remove and recreate containers:
    `make down`
    <sup>I did `docker-compose down --volumes --rmi all` just to be sure.)</sup>
    `make init_dbs`
    `docker ps`
3. Verify a container `authenticator_postgres_1` exists.

I did this — it worked:

4. Have environment with Docker Compose v2.
5. Repeat step # 2.
6. Repeat step # 3.

</details>
<details><summary>

### Long Way

</summary>

1. Have environment with Docker Compose v1.
2. Remove and recreate containers:
    `make down`
    <sup>I did `docker-compose down --volumes --rmi all` just to be sure.)</sup>
    `make init_dbs`
    `make migrate.upgrade`
    `docker-compose up -d authenticator`
3. Verify http://localhost:5000/v3/oauth2/webapp loads the UI.

I did this — it worked:

4. Have environment with Docker Compose v2.
5. Repeat step # 2.
6. Repeat step # 3.

</details>

## Notes

https://stackoverflow.com/a/69519102/11817077