### PR TITLE
feat: sync /service/ from host to container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
             - "5000:5000"
         volumes:
             - ./config-local.json:/home/tapis/config.json
+            - ./service:/home/tapis/service
             # - ./config-local-uh.json:/home/tapis/config.json
             # - ./config-local-sdsc.json:/home/tapis/config.json
             - ./service.log:/home/tapis/service.log


### PR DESCRIPTION
## Overview

Support changes to service files on host syncing to running container.

This allows, at least, edits to templates and images to propagate to server.

## Changes

- **added** volume to `authenticator` service

## Testing

0. Have functional project.
1. Run web UI e.g. `docker-compose up -d authenticator`.
2. Load http://localhost:5000/v3/oauth2/tenant.
3. On host, add a button `<button name="tenant" value="dev">Dev Tenant</button>`.
4. Refresh http://localhost:5000/v3/oauth2/tenant.
5. Verify new button is shown.

## Notes

If this should already be working without change, please close this PR and (if convenient) explain why it should work so I can debug why it failed for me.