### PR TITLE
feat: GH-81 loading spinner button

### DIFF
--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -48,7 +48,7 @@ body {
   const loadingContent = loadingTemplate.content.cloneNode(true);
 
   form.addEventListener('submit', (event) => {
-    submitButton.setAttribute('data-status', 'busy');
+    submitButton.setAttribute('data-state', 'busy');
     submitButton.append(...loadingContent.childNodes);
   });
 </script>

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -3,7 +3,7 @@
 {% block assets %}
 {{ super() }}
 
-{% with core_styles_cdn_url="https://unpkg.com/@tacc/core-styles@2.17.5" %}
+{% with core_styles_cdn_url="https://unpkg.com/@tacc/core-styles@2.28.0" %}
 <style>
   /* base styles */
   @import url('{{ core_styles_cdn_url }}/dist/core-styles.settings.css') layer(base);

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -3,7 +3,7 @@
 {% block assets %}
 {{ super() }}
 
-{% with core_styles_cdn_url="https://unpkg.com/@tacc/core-styles@2.28.0" %}
+{% with core_styles_cdn_url="https://cdn.jsdelivr.net/gh/TACC/Core-Styles@ba46e9a" %}
 <style>
   /* base styles */
   @import url('{{ core_styles_cdn_url }}/dist/core-styles.settings.css') layer(base);
@@ -20,6 +20,8 @@
   @import url('{{ core_styles_cdn_url }}/dist/trumps/s-form--portal.css') layer(project);
   @import url('{{ core_styles_cdn_url }}/dist/settings/color--portal.css') layer(project);
   @import url('{{ core_styles_cdn_url }}/dist/settings/font--portal.css') layer(project);
+  /* NOTE: authenticator uses v3 but that version does not have a spinner */
+  @import url('{{ core_styles_cdn_url }}/dist/vendors/bootstrap5--border-spinner.css') layer(project);
 </style>
 {% endwith %}
 {% endblock %}
@@ -35,6 +37,22 @@ body {
   min-height: 100vh;
 }
 </style>
+<template id="loading-content">
+  <span class="sr-only" role="status">Loading...</span>
+  <span class="spinner-border" aria-hidden="true"></span>
+</template>
+<script type="module">
+  const form = document.querySelector('form');
+  const submitButton = form.querySelector('[type="submit"]');
+  const loadingTemplate = document.getElementById('loading-content');
+  const loadingContent = loadingTemplate.content.cloneNode(true);
+
+  form.addEventListener('submit', (event) => {
+    submitButton.setAttribute('data-status', 'busy');
+    submitButton.append(...loadingContent.childNodes);
+    event.preventDefault();
+  });
+</script>
 {% endblock %}
 
 {# So banner is NOT rendered #}

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -3,7 +3,7 @@
 {% block assets %}
 {{ super() }}
 
-{% with core_styles_cdn_url="https://cdn.jsdelivr.net/gh/TACC/Core-Styles@ba46e9a" %}
+{% with core_styles_cdn_url="https://cdn.jsdelivr.net/npm/@tacc/core-styles@v2.29.1" %}
 <style>
   /* base styles */
   @import url('{{ core_styles_cdn_url }}/dist/core-styles.settings.css') layer(base);

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -50,7 +50,6 @@ body {
   form.addEventListener('submit', (event) => {
     submitButton.setAttribute('data-status', 'busy');
     submitButton.append(...loadingContent.childNodes);
-    event.preventDefault();
   });
 </script>
 {% endblock %}


### PR DESCRIPTION
## Overview

Add loading icon on submit button for MFA.

## Related

- closes #81
- requires https://github.com/TACC/Core-Styles/pull/359
- requires https://github.com/TACC/Core-Styles/pull/361

## Changes

- **updated** Core-Styles
- **added** Bootstrap5 "Border spinner"
- **added** submit button loading state

## Testing

0. Open `/v3/oauth2/webapp`.
1. Submit form.
2. Verify button becomes disabled and has loading spinner.
3. Verify button has accessible "Loading…" text during loading state.

## UI

### UI State & Error

https://github.com/user-attachments/assets/3d5cbd37-cd73-4b38-aaa4-82b9a77a2f6a

### Accessibility

https://github.com/user-attachments/assets/e88fa832-4d50-444f-8cd9-4e53660386fb