### PR TITLE
enhance: GH-82 do not autofill old mfa tokens

### DIFF
--- a/service/controllers.py
+++ b/service/controllers.py
@@ -620,7 +620,7 @@ class MFAResource(Resource):
         except Exception as e:
             logger.debug(f"Error getting client display name. e: {e}")
 
-        # to let us make field name unique (to prevet autofill)
+        # to let us make field name unique (to prevet autofill of old tokens)
         mfa_token_ident = str(random.random())[3:]
 
         logger.info(f"Source: {request.args.get('source', None)}")

--- a/service/controllers.py
+++ b/service/controllers.py
@@ -14,6 +14,7 @@ from openapi_core import openapi_request_validator
 from openapi_core.contrib.flask import FlaskOpenAPIRequest
 import sqlalchemy
 import secrets
+import random
 
 from tapisservice import errors
 from tapisservice.tapisflask import utils
@@ -619,6 +620,9 @@ class MFAResource(Resource):
         except Exception as e:
             logger.debug(f"Error getting client display name. e: {e}")
 
+        # to let us make field name unique (to prevet autofill)
+        mfa_token_ident = str(random.random())[3:]
+
         logger.info(f"Source: {request.args.get('source', None)}")
         logger.info(f"User Code: {request.args.get('user_code', None)}")
 
@@ -628,6 +632,7 @@ class MFAResource(Resource):
                    'client_redirect_uri': client_redirect_uri,
                    'client_state': client_state,
                    'tenant_id': tenant_id,
+                   'mfa_token_name': 'mfa_token_' + mfa_token_ident,
                    'username': session.get('username'),
                    'user_code': request.args.get('user_code', None),
                    'source': request.args.get('source', None)}
@@ -645,7 +650,8 @@ class MFAResource(Resource):
             logger.debug(
                 f"did not find tenant_id in session; issuing redirect to LoginResource. session: {session}")
             return redirect(url_for('loginresource'), 200, headers)
-        mfa_token = request.form.get('mfa_token')
+        mfa_token_name = request.form.get('mfa_token_name')
+        mfa_token = request.form.get(mfa_token_name)
         source = request.form.get('source', None)
         user_code = request.form.get('user_code', None)
 
@@ -680,7 +686,8 @@ class MFAResource(Resource):
                                     source=source))
         else:
             context = {'error': response,
-                   'username': session.get('username')}
+                       'username': session.get('username'),
+                       'mfa_token_name': mfa_token_name}
             return make_response(render_template('mfa.html', **context), 200, headers)
 
 

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -27,7 +27,8 @@
       </div>
       <div class="has-required">
          <label for="mfa_token">Token</label>
-         <input id="mfa_token" type="text" name="mfa_token" placeholder="Enter MFA Token" required>
+         <input id="mfa_token" type="text" name="{{ mfa_token_name }}" placeholder="Enter MFA Token" required>
+         <input type="hidden" name="mfa_token_name" value="{{ mfa_token_name }}">
          <input type="hidden" name="client_id" value="{{ client_id }}">
          <input type="hidden" name="client_redirect_uri" value="{{ client_redirect_uri }}">
          <input type="hidden" name="client_display_name" value="{{ client_display_name }}">


### PR DESCRIPTION
## Overview

Do **not** let browser autocomplete "Token" field with old value.

> [!NOTE]
> The solution I used is [a dynamic field name](https://stackoverflow.com/a/218453/11817077). To use `autocomplete="off"` would cancel #85's `autocomplete="one-time-pass"` solution.

## Related

- closes GH-82
- ⚠️ changes same HTML as
    #85

## Testing & UI

<details open><summary>Prerequisites</summary>

- Have [MFA](https://docs.tacc.utexas.edu/basics/mfa/) enabled for a Tapis tenant.

</details>

1. Open http://localhost:5000/v3/oauth2/tenant.
2. Select any tenant for which MFA is enabled.
3. Log in.
4. Submit valid MFA token.
5. ✅ Verify MFA succeeds.
6. Log out (via http://localhost:5000/v3/oauth2/logout).
7. Repeat steps 1 through 3.
8. Focus on MFA Token field.
9. ✅✅ Verify previously filled value is not shown.
10. Enter incorrect value.
11. Submit.
12. Page/Form reloads with error.
13. Submit valid MFA token.
14. ✅ Verify MFA succeeds.

<img width="1085" alt="GH-82" src="https://github.com/user-attachments/assets/8686a7cb-2683-4856-887d-3ffe7cde9135">