### PR TITLE
fix: incomplete conflict resolution

### DIFF
--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -40,8 +40,8 @@
 <template id="loading-content">
   <span class="sr-only" role="status">Loading...</span>
   <span class="spinner-border" aria-hidden="true"></span>
-  </template>
-  <script type="module">
+</template>
+<script type="module">
     const form = document.querySelector('form');
     const submitButton = form.querySelector('[type="submit"]');
     const loadingTemplate = document.getElementById('loading-content');

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -37,7 +37,7 @@
     min-height: 100vh;
   }
 </style>
-<<<<<<< HEAD <template id="loading-content">
+<template id="loading-content">
   <span class="sr-only" role="status">Loading...</span>
   <span class="spinner-border" aria-hidden="true"></span>
   </template>
@@ -46,24 +46,20 @@
     const submitButton = form.querySelector('[type="submit"]');
     const loadingTemplate = document.getElementById('loading-content');
     const loadingContent = loadingTemplate.content.cloneNode(true);
+    const fields = form.querySelectorAll('input:not([hidden], select, textarea');
 
     form.addEventListener('submit', (event) => {
+      /* To show user the submission is in progress */
       submitButton.setAttribute('data-state', 'busy');
       submitButton.append(...loadingContent.childNodes);
-=======
-<script type="module">
-  const form = document.querySelector('form');
-  const fields = form.querySelectorAll('input:not([hidden], select, textarea');
 
-  form.addEventListener('submit', (event) => {
-    /* To show user what was entered is what will be processed */
-    [...fields].forEach(field => {
-      field.setAttribute('readonly', '');
+      /* To show user what was entered is what will be processed */
+      [...fields].forEach(field => {
+        field.setAttribute('readonly', '');
+      });
     });
->>>>>>> 792e0a6a2310b10973900f415d34c2596ed9db17
-    });
-  </script>
-  {% endblock %}
+</script>
+{% endblock %}
 
   {# So banner is NOT rendered #}
   {% block banner %}


### PR DESCRIPTION
### Overview / Changes

Fix incomplete conflict resolution from 81e8720.

<details>

I found `<<<<<<< HEAD`, `=======`, and `>>>>>>> 792e0a6…` still in the code.

</details>

### Related / Testing

- #78
- #83

## UI

| MFA Autofill | Submit |
| - | - |
| <img width="1192" alt="mfa autofill" src="https://github.com/user-attachments/assets/f7275d33-4325-4471-a665-55a45e9635de"> | <img width="1193" alt="submit" src="https://github.com/user-attachments/assets/3449826d-e9c1-47b9-8232-139c5aba20d1"> |