### PR TITLE
feat: GH-80 designsafe mfa form description

### DIFF
--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -15,6 +15,13 @@
          <span>Enter MFA Token</span>
       </h1>
 
+      {% if tenant_id == "tacc" %}
+      {# {% if tenant_id == "designsafe" %} #}
+      <p>
+         Multi-Factor Authentication (MFA) is now required. <small><a href="https://docs.tacc.utexas.edu/basics/mfa/" target="_blank">Set up MFA</a> via the <span>TACC&nbsp;User&nbsp;Portal</span>. Pair via an <span>MFA application</span>, not <span>SMS (text)</span>.</small>
+      <p>
+      {% endif %}
+
       {% if error %}
          <ul>
             <li>Error: {{ error }}</li>
@@ -42,4 +49,21 @@
       </footer>
    </form>
 </main>
+{% endblock %}
+
+{% block head_extra %}
+{{ super() }}
+<style>
+   /* To not let certain words break when paragraph is wrapped */
+   /* FAQ: This seemed more robust for other editors than `&nbsp;` */
+  .s-form > p :is(a, span) {
+    white-space: nowrap;
+  }
+
+   /* To allow non-bold text in form descritpion */
+  .s-form > p small {
+    font-size: inherit;
+    font-weight: var(--regular);
+  }
+</style>
 {% endblock %}

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -15,10 +15,9 @@
          <span>Enter MFA Token</span>
       </h1>
 
-      {% if tenant_id == "tacc" %}
-      {# {% if tenant_id == "designsafe" %} #}
+      {% if tenant_id == "designsafe" %}
       <p>
-         Multi-Factor Authentication (MFA) is now required. <small><a href="https://docs.tacc.utexas.edu/basics/mfa/" target="_blank">Set up MFA</a> via the <span>TACC&nbsp;User&nbsp;Portal</span>. Pair via an <span>MFA application</span>, not <span>SMS (text)</span>.</small>
+         Multi-Factor Authentication (MFA) is now required. <small><a href="https://docs.tacc.utexas.edu/basics/mfa/" target="_blank">Set up MFA</a> via the <span>TACC&nbsp;User&nbsp;Portal</span>.</small>
       <p>
       {% endif %}
 


### PR DESCRIPTION
## Overview

Explain MFA (new requirement for user login).

## Related

- closes GH-80

## Changes

- **added** description
- **added** styles

## Testing

1. Choose DesignSafe tenant that has set up MFA.
    <sub>If you do not have that, then change [line 18](https://github.com/wesleyboar/tapis-project-authenticator/blob/feat/GH-80-explain-mfa/service/templates/mfa.html#L18) to id of MFA tenant.</sub>
3. Have or set up MFA for tenant.
4. Visit login (via `/v3/oauth2/webapp`).
5. Log in.
6. Review MFA form description.

## UI

<img width="735" alt="GH-80 Slimmer" src="https://github.com/user-attachments/assets/b57e1d95-0003-4cd4-8c22-515f4de3cf63">

> [!NOTE]
> The "MFA app not SMS" part is not mentioned[^1] because [Select Pairing Method](https://docs.tacc.utexas.edu/basics/mfa/#setupmfa-step2) of MFA doc exclaims it to user.

<details><summary>narrow screens</summary>

https://github.com/user-attachments/assets/0f10c141-f466-4598-96b5-d7d77108b87c

</details>

[^1]: A description that mentioned that was tested ([screenshot](https://github.com/user-attachments/assets/552a041a-e657-4524-aad3-27764372be50), [video](https://github.com/user-attachments/assets/f5830c97-6d99-410b-b5b1-00f1b848c3cd)).