### PR TITLE
fix: misc mfa form features

### DIFF
--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -43,15 +43,17 @@
 </template>
 <script type="module">
     const form = document.querySelector('form');
-    const submitButton = form.querySelector('[type="submit"]');
+    const submitButtons = form.querySelectorAll('[type="submit"]');
     const loadingTemplate = document.getElementById('loading-content');
     const loadingContent = loadingTemplate.content.cloneNode(true);
     const fields = form.querySelectorAll('input:not([hidden], select, textarea');
 
     form.addEventListener('submit', (event) => {
       /* To show user the submission is in progress */
-      submitButton.setAttribute('data-state', 'busy');
-      submitButton.append(...loadingContent.childNodes);
+      if (submitButtons.length === 1) {
+        submitButton[0].setAttribute('data-state', 'busy');
+        submitButton[0].append(...loadingContent.childNodes);
+      }
 
       /* To show user what was entered is what will be processed */
       [...fields].forEach(field => {

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -16,7 +16,7 @@
       </h1>
 
       <p>
-         Multi-Factor Authentication (MFA) is now required. <small><a href="https://docs.tacc.utexas.edu/basics/mfa/" target="_blank">Set up MFA</a> via the <span>TACC&nbsp;User&nbsp;Portal</span>.</small>
+         Multi-Factor Authentication (MFA) is now required. <br /><small><a href="https://docs.tacc.utexas.edu/basics/mfa/" target="_blank">Set up MFA</a> via the <span>TACC&nbsp;User&nbsp;Portal</span>.</small>
       <p>
 
       {% if error %}

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -15,11 +15,9 @@
          <span>Enter MFA Token</span>
       </h1>
 
-      {% if tenant_id == "designsafe" %}
       <p>
          Multi-Factor Authentication (MFA) is now required. <small><a href="https://docs.tacc.utexas.edu/basics/mfa/" target="_blank">Set up MFA</a> via the <span>TACC&nbsp;User&nbsp;Portal</span>.</small>
       <p>
-      {% endif %}
 
       {% if error %}
          <ul>

--- a/service/templates/select_idp.html
+++ b/service/templates/select_idp.html
@@ -65,16 +65,16 @@
     gap: 0.5em;
   }
   .button-list button {
-    min-width: 40rem; /* to limit button width but allow wider */
+    min-width: 30rem; /* to limit button width but allow wider */
 
     /* To position button content */
-    text-align: start;
-    padding-left: 1em;
+    align-items: center;
+    justify-content: left;
   }
   .button-list button img {
     width: 8rem;
     height: 4rem;
-    margin-right: 0.5em;
+    margin-right: 1em;
   }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Overview

Misc. fixes since recent MFA features.

## Testing / Related / Changes

- **any MFA tenant should have the MFA form desc**
    <sup>was only DS in #90</sup>
- MFA form desc line break between sentences
    <sup>forgotten for #90</sup>
- no need for loading on IDP form buttons
    <sup>a bug from #78</sup>
- IDP form buttons more organized
    <sup>a Core-Styles update must have messed them up</sup>

## UI

| | before | after |
| - | - | - |
| mfa | <img width="735" alt="mfa before" src="https://github.com/user-attachments/assets/a26001f9-9128-4ca8-bd15-0f6d7637aa18"> | <img width="735" alt="mfa after" src="https://github.com/user-attachments/assets/070e845d-253b-458f-a2ff-e999d89a7aca"> |
| idp | <img width="735" alt="idp before" src="https://github.com/user-attachments/assets/e7bc670f-62a2-4a62-a1c9-b2e67abd7ded"> | <img width="735" alt="idp after" src="https://github.com/user-attachments/assets/66cdfdeb-d77b-47a6-a065-5ee6a536ed4c"> | 