### PR TITLE
fix: mfa misc round 2 (e.g. disable submit button)

### DIFF
--- a/service/controllers.py
+++ b/service/controllers.py
@@ -626,9 +626,6 @@ class MFAResource(Resource):
         except Exception as e:
             logger.debug(f"Error getting client display name. e: {e}")
 
-        # to let us make field name unique (to prevet autofill of old tokens)
-        mfa_token_ident = str(random.random())[3:]
-
         logger.info(f"Source: {request.args.get('source', None)}")
         logger.info(f"User Code: {request.args.get('user_code', None)}")
 
@@ -638,7 +635,7 @@ class MFAResource(Resource):
                    'client_redirect_uri': client_redirect_uri,
                    'client_state': client_state,
                    'tenant_id': tenant_id,
-                   'mfa_token_name': 'mfa_token_' + mfa_token_ident,
+                   'mfa_token_name': self.create_token(),
                    'username': session.get('username'),
                    'user_code': request.args.get('user_code', None),
                    'source': request.args.get('source', None)}
@@ -693,9 +690,16 @@ class MFAResource(Resource):
         else:
             context = {'error': response,
                        'username': session.get('username'),
-                       'mfa_token_name': mfa_token_name}
+                       'mfa_token_name': self.create_token()}
             return make_response(render_template('mfa.html', **context), 200, headers)
 
+    def create_token(self):
+        """
+        Create unique token field name (to prevet autofill of old tokens)
+        """
+        mfa_token_ident = str(random.random())[3:]
+
+        return 'mfa_token_' + mfa_token_ident
 
 class DeviceFlowResource(Resource):
     """

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -58,7 +58,7 @@
 
         /* To not disable buttons that have a value to submit */
         /* FAQ: Or else value will not be submitted */
-        if ( ! submitButton.hasAttribute(value)) {
+        if ( ! submitButton.hasAttribute('value')) {
           submitButton.setAttribute('disabled', '');
         }
       }

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -52,6 +52,7 @@
       /* To show user the submission is in progress */
       if (submitButtons.length === 1) {
         submitButtons[0].setAttribute('data-state', 'busy');
+        submitButtons[0].setAttribute('disabled', '');
         submitButtons[0].append(...loadingContent.childNodes);
       }
 

--- a/service/templates/base-auth.html
+++ b/service/templates/base-auth.html
@@ -51,9 +51,16 @@
     form.addEventListener('submit', (event) => {
       /* To show user the submission is in progress */
       if (submitButtons.length === 1) {
-        submitButtons[0].setAttribute('data-state', 'busy');
-        submitButtons[0].setAttribute('disabled', '');
-        submitButtons[0].append(...loadingContent.childNodes);
+        const submitButton = submitButtons[0];
+
+        submitButton.setAttribute('data-state', 'busy');
+        submitButton.append(...loadingContent.childNodes);
+
+        /* To not disable buttons that have a value to submit */
+        /* FAQ: Or else value will not be submitted */
+        if ( ! submitButton.hasAttribute(value)) {
+          submitButton.setAttribute('disabled', '');
+        }
       }
 
       /* To show user what was entered is what will be processed */

--- a/service/templates/login.html
+++ b/service/templates/login.html
@@ -24,7 +24,7 @@
 
     <div class="has-required">
       <label for="username">Username</label>
-      <input id="username" type="text" name="username" required autocomplete="username">
+      <input id="username" type="text" name="username" autofocus required autocomplete="username">
     </div>
     <div class="has-required">
       <label for="password">Password</label>

--- a/service/templates/mfa.html
+++ b/service/templates/mfa.html
@@ -31,7 +31,7 @@
       </div>
       <div class="has-required">
          <label for="mfa_token">Token</label>
-         <input id="mfa_token" type="text" name="{{ mfa_token_name }}" placeholder="Enter MFA Token" required autocomplete="one-time-pass">
+         <input id="mfa_token" type="text" name="{{ mfa_token_name }}" placeholder="Enter MFA Token" autofocus required autocomplete="one-time-pass">
          <input type="hidden" name="mfa_token_name" value="{{ mfa_token_name }}">
          <input type="hidden" name="client_id" value="{{ client_id }}">
          <input type="hidden" name="client_redirect_uri" value="{{ client_redirect_uri }}">


### PR DESCRIPTION
> [!IMPORTANT]
> Accidentally closed. See #95 instead.

<details><summary>Archived</summary>

## Overview

Misc. Fixes, Round 2

## Changes / Testing / UI

<details><summary>1. On submit, <em>truly</em> disable button. (f0dcfae, 6a2cae0, 085a8cb, 085a8cb)</summary>

0. (optional) In console, pause form on submit:
    <sup>`document.querySelector('form').addEventListener('submit', (event) => { event.preventDefault(); });`.</sup>
1. Submit form.
2. Hover cursor over submit button.
3. Verify pointer is **not** a pointing hand.\
    (Verify button has attribute `disabled`.)

<img width="1280" alt="button is disabled" src="https://github.com/user-attachments/assets/4af81d8e-4095-48eb-9f17-2a9ff4bac941">

</details>

<details><summary>2. Do not remember failed MFA tokens. (b3540e1)</summary>

1. Submit MFA form with wrong token.
2. After submit fails, focus on MFA field.
3. Verify previous (failed) token is not available as autofill.

https://github.com/user-attachments/assets/d58d29c2-e132-4001-a55d-38bcdeeddff6

</details>

<details><summary>3. Auto-focus "Username" and "Token" fields. (56cf276)</summary>

1. On Login form, notice "Username" field, auto-receives focus.
2. On MFA form, notice "Token" field auto-receives focus.

https://github.com/user-attachments/assets/dcef5f8e-ffc2-4228-a0f6-78ca354b87eb

https://github.com/user-attachments/assets/960dd7b8-2646-41d4-a9f0-c1088dfe6a3d

</details>

</details>