### PR TITLE
Preliminary OIDC support. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ hashids==1.2.0
 ldap3
 requests
 flask-wtf
+jwcrypto

--- a/service/api.py
+++ b/service/api.py
@@ -8,8 +8,8 @@ from service.auth import authn_and_authz
 from service.controllers import AuthorizeResource, ClientsResource, ClientResource, TokensResource, \
     ProfilesResource, ProfileResource, StaticFilesResource, LoginResource, SetTenantResource, LogoutResource, \
     WebappTokenGen, WebappTokenAndRedirect, TenantConfigResource, UserInfoResource, OAuth2ProviderExtCallback, \
-    OAuthMetadataResource, MFAResource, DeviceFlowResource, DeviceCodeResource, V2TokenResource, \
-    RevokeTokensResource, SetIdentityProvider, WebappLogout
+    OAuthMetadataResource, OIDCMetadataResource, MFAResource, DeviceFlowResource, DeviceCodeResource, V2TokenResource, \
+    RevokeTokensResource, SetIdentityProvider, WebappLogout, OIDCjwksResource, OIDCTokensResource#, OIDCUserInfoResource
 from service.ldap import populate_test_ldap
 from service.models import db, app, initialize_tenant_configs
 
@@ -74,6 +74,11 @@ api.add_resource(TokensResource, '/v3/oauth2/tokens')
 api.add_resource(UserInfoResource, '/v3/oauth2/userinfo')
 api.add_resource(ProfilesResource, '/v3/oauth2/profiles')
 api.add_resource(ProfileResource, '/v3/oauth2/profiles/<username>')
+
+# API OIDC resources
+#api.add_resource(OIDCMetadataResource, '/v3/oauth2/.well-known/openid-configuration')
+api.add_resource(OIDCjwksResource, '/v3/oauth2/jwks')
+api.add_resource(OIDCTokensResource, '/v3/oauth2/tokens/oidc')
 
 # Auth server resources
 api.add_resource(AuthorizeResource, '/v3/oauth2/authorize')

--- a/service/auth.py
+++ b/service/auth.py
@@ -55,7 +55,7 @@ def authentication():
     # The authenticator uses different authentication methods for different endpoints. For example, the service
     # APIs such as clients and profiles use pure JWT authentication, while the OAuth endpoints use Basic Authentication
     # with OAuth client credentials.
-    logger.debug(f"base_url: {request.base_url}; url_rule: {request.url_rule}")
+    logger.debug(f"Top of authentication(). base_url: {request.base_url}; url_rule: {request.url_rule}")
     if not hasattr(request, 'url_rule') or not hasattr(request.url_rule, 'rule') or not request.url_rule.rule:
         raise common_errors.ResourceError("The endpoint and HTTP method combination "
                                           "are not available from this service.")
@@ -65,6 +65,12 @@ def authentication():
         logger.debug(".well-known endpoint; request is allowed to be made unauthenticated.")
         auth.resolve_tenant_id_for_request()
         return True
+
+    if "/v3/oauth2/jwks" in request.url_rule.rule:
+        logger.debug("jwks endpoint; request is allowed to be made unauthenticated.")
+        auth.resolve_tenant_id_for_request()
+        return True
+
     # only the authenticator's own service token and tenant admins for the tenant can retrieve or modify the tenant
     # config
     if '/v3/oauth2/admin' in request.url_rule.rule:
@@ -192,7 +198,7 @@ def authentication():
                 raise common_errors.BaseTapisError("Unable to resolve tenant_id for request.")
             return True
 
-    # Token Revokcation Endpoint -----
+    # Token Revocation Endpoint -----
     if '/v3/oauth2/tokens/revoke' in request.url_rule.rule:
         # anyone with a token is currently allowed to revoke it. the only issue is whether this tokens API
         # should revoke it. 

--- a/service/controllers.py
+++ b/service/controllers.py
@@ -5,10 +5,11 @@ import requests
 from requests.auth import HTTPBasicAuth
 import json
 import time
-from flask import g, request, Response, render_template, redirect, make_response, send_from_directory, session, url_for
+from flask import g, request, Response, render_template, redirect, make_response, send_from_directory, session, url_for, jsonify
 from flask_restful import Resource
 from openapi_core import openapi_request_validator
 from openapi_core.contrib.flask import FlaskOpenAPIRequest
+from jwcrypto import jwk
 import sqlalchemy
 import secrets
 import random
@@ -44,6 +45,7 @@ class OAuthMetadataResource(Resource):
     See https://datatracker.ietf.org/doc/html/rfc8414
     """
     def get(self):
+        logger.info("top of GET /v3/oauth2/.well-known/oauth-authorization-server")
         tenant_id = g.request_tenant_id
         config = tenant_configs_cache.get_config(tenant_id)
         allowable_grant_types = json.loads(config.allowable_grant_types)
@@ -203,7 +205,7 @@ class ProfilesResource(Resource):
 
 class UserInfoResource(Resource):
     def get(self):
-        logger.debug(f'top of GET /userinfo')
+        logger.debug(f'top of GET /v3/oauth2/userinfo')
         tenant_id = g.request_tenant_id
         # note that the user info endpoint is more limited for custom oauth idp extensions in general because the
         # custom OAuth server may not provider a profile endpoint.
@@ -218,7 +220,7 @@ class UserInfoResource(Resource):
 
 class ProfileResource(Resource):
     def get(self, username):
-        logger.debug(f'top of GET /profiles/{username}')
+        logger.debug(f'top of GET /v3/profiles/{username}')
         tenant_id = g.request_tenant_id
         # note that the user info endpoint is more limited for custom oauth idp extensions in general because the
         # custom OAuth server may not provider a profile endpoint.
@@ -353,6 +355,56 @@ class TenantConfigResource(Resource):
 
 
 # ---------------------------------
+# OIDC endpoints
+# ---------------------------------
+
+# class OIDCMetadataResource(Resource):
+#     """
+#     Provides the OIDC .well-known endpoint.
+#     """
+#     def get(self):
+#         logger.info("top of GET /v3/oauth2/.well-known/openid-configuration")
+#         tenant_id = g.request_tenant_id
+#         config = tenant_configs_cache.get_config(tenant_id)
+#         allowable_grant_types = json.loads(config.allowable_grant_types)
+#         tenant = t.tenant_cache.get_tenant_config(tenant_id=tenant_id)
+#         base_url = tenant.base_url
+#         json_response = {
+#             'issuer': f'{base_url}/v3/tokens',
+#             'authorization_endpoint': f'{base_url}/v3/oauth2/authorize',
+#             'token_endpoint': f'{base_url}/v3/oauth2/tokens/oidc?oidc=true',
+#             'jwks_uri': f'{base_url}/v3/oauth2/jwks',
+#             'registration_endpoint': f'{base_url}/v3/oauth2/clients',
+#             'grant_types_supported': allowable_grant_types,
+#             'userinfo_endpoint': f'{base_url}/v3/oauth2/userinfo/oidc',
+#         }
+#         return json_response #utils.ok(result=metadata, msg='OAuth OIDC metadata retrieved successfully.')
+
+
+class OIDCjwksResource(Resource):
+    """
+    Provides the OIDC jwks endpoint.
+    """
+    def get(self):
+        logger.info("top of GET /v3/oauth2/jwks")
+        tenant_id = g.request_tenant_id
+        config = tenant_configs_cache.get_config(tenant_id)
+        allowable_grant_types = json.loads(config.allowable_grant_types)
+        tenant = t.tenant_cache.get_tenant_config(tenant_id=tenant_id)
+        base_url = tenant.base_url
+        
+        # unpack jwks info from tenant public key
+        pem_key = tenant.public_key
+        key = jwk.JWK.from_pem(pem_key.encode('utf-8'))
+        jwk_json = key.export(as_dict=True)
+
+        json_response = {
+            'keys': [jwk_json]
+        }
+        return json_response #utils.ok(result=metadata, msg='OAuth OIDC metadata retrieved successfully.')
+
+
+# ---------------------------------
 # Authorization Server controllers
 # ---------------------------------
 
@@ -363,7 +415,7 @@ def check_client(use_session=False):
     and returns the associated objects.
 
     If use_session is True, this function will check for the client credentials out of the session. This is
-    used when the tenant is configured with a 3rd-party OAuth2 sever that does not pass back the original
+    used when the tenant is configured with a 3rd-party OAuth2 server that does not pass back the original
     client credentials.
     """
     # tenant_id should be determined by the request URL -
@@ -424,6 +476,8 @@ def check_client(use_session=False):
         raise errors.ResourceError("Required query parameter redirect_uri missing.")
     if not client.callback_url == client_redirect_uri:
         logout()
+        # cgarcia - I'm not sure if the uris should be exact or if only domain should match. But I'll leave this as is.
+        logger.debug(f"redirect_uri query parameter does not match registered callback_url for the client. redirect_uri: {client_redirect_uri}; callback_url: {client.callback_url}")
         raise errors.ResourceError(
             "redirect_uri query parameter does not match the registered callback_url for the client.")
     return client_id, client_redirect_uri, client_state, client, response_type
@@ -867,7 +921,7 @@ class AuthorizeResource(Resource):
     """
 
     def get(self):
-        logger.info("top of GET /oauth2/authorize")
+        logger.info("top of GET /v3/oauth2/authorize")
         is_device_flow = True if 'device_login' in session else False
         # if we are using the multi_idp custom oa2 extension type it is possible we are being redirected here, not by the 
         # original web client, but by our select_idp page, in which case we need to get the client out of the session.
@@ -1000,7 +1054,7 @@ class AuthorizeResource(Resource):
         return make_response(render_template('authorize.html', **context), 200, headers)
 
     def post(self):
-        logger.debug("top of POST /oauth2/authorize")
+        logger.info("top of POST /v3/oauth2/authorize")
         # selecting a tenant id is required before logging in -
         tenant_id = g.request_tenant_id
         if not tenant_id:
@@ -1210,7 +1264,7 @@ class OAuth2ProviderExtCallback(Resource):
       GET /v3/oauth2/extensions/oa2/callback -- receive the authorization code and exchange it for a token.
     """
     def get(self):
-        logger.debug("top of GET /oauth2/extensions/oa2/callback")
+        logger.info("top of GET /v3/oauth2/extensions/oa2/callback")
         # use tenant id to create the tenant oa2 extension config
         tenant_id = g.request_tenant_id
         session['tenant_id'] = tenant_id
@@ -1259,7 +1313,7 @@ class OAuth2ProviderExtCallback(Resource):
                                 response_type='code'))
 
 
-class TokensResource(Resource):
+def _handle_tokens_request(request, oidc=False):
     """
     Implements the oauth2/tokens endpoint for generating tokens for the following grant types:
       * password
@@ -1267,9 +1321,8 @@ class TokensResource(Resource):
       * refresh_token
       * device_code
     """
-
-    def post(self):
-        logger.debug("top of POST /oauth2/tokens")
+    if oidc or not oidc:
+        logger.info("top of POST /v3/oauth2/tokens")
         # support content-type www-form by setting the body on the request equal to the JSON        
         if request.content_type.startswith('application/x-www-form-urlencoded'):
             logger.debug(f"handling x-www-form data")
@@ -1456,6 +1509,12 @@ class TokensResource(Resource):
         }
         if idp_id:
             content['claims']['tapis/idp_id'] = idp_id
+        if oidc:
+            if client_id:
+                content['claims']['aud'] = client_id
+            content['claims']['iat'] = int(time.time())
+            content['claims']['extravar'] = username
+            content['claims']['email'] = username
 
         # only generate a refresh token when OAuth client is passed
         if client_id and client_key:
@@ -1561,8 +1620,29 @@ class TokensResource(Resource):
                   f"Contact system administrator. (Debug data: {e})"
             logger.error(msg)
             raise errors.ResourceError(f"{msg}")
-        
+
+        if oidc:
+            logger.info("Token endpoint with OIDC flag set.")
+            response_json = {
+                'access_token': result['access_token']['access_token'],
+                'expires_in': result['access_token']['expires_in'],
+                'token_type': 'Bearer',
+                'id_token': result['access_token']['id_token']}
+            logger.info(f"OIDC response: {response_json}")
+            # oidc endpoints aren't expecting our tapis 5 stanza response.
+            return jsonify(response_json)
+
         return utils.ok(result=result, msg="Token created successfully.")
+
+
+class TokensResource(Resource):
+    def post(self):
+        return _handle_tokens_request(request, oidc=False)
+
+
+class OIDCTokensResource(Resource):
+    def post(self):
+        return _handle_tokens_request(request, oidc=True)
 
 
 class V2TokenResource(Resource):


### PR DESCRIPTION
Added oidc endpoints that return non-stanza'd responses + added variables. Added jwks endpoint. Tokens is in charge of `.well-known/openid-configuration` endpoint as issuers must be on the same url for some apps.

Tokens API OIDC changes are in this commit: https://github.com/tapis-project/tokens-api/commit/fb9c4f48839e8e7b8bd182ae8a3fc923cecf020e

My biggest issue is that the tokens API `/.well-known/openid-configuration` is grabbing tenant information without a tenant cache object. That might want to be optimized. Tokens code doesn't have all of those models though, only Tenants.