### PR TITLE
fix: update endpoint in README for OAuth token request

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Your client application code should handle this GET request by making a request 
 the authorization code for an OAuth token. 
 
 ```
-4) POST http://localhost:5000/v3/oauth2/token
+4) POST http://localhost:5000/v3/oauth2/tokens
         grant_type=authorization_code
         code=<some_code>
         redirect_uri=<your_redirct_uri>


### PR DESCRIPTION
Minor tweak to fix URL shown in example POST for getting tokens during oauth2 flow.