### PR TITLE
Fix device code flow completing before TTL form submission

### DIFF
--- a/service/controllers.py
+++ b/service/controllers.py
@@ -1572,6 +1572,7 @@ class AuthorizeResource(Resource):
                 device_code.access_token_ttl = int(ttl) * 60 * 60 * 24
             if session.get("idp_id"):
                 device_code.tapis_idp_id = session.get("idp_id")
+            device_code.status = "Authorized"
             try:
                 logger.info(f"Updating device code: {device_code}")
                 db.session.commit()

--- a/service/models.py
+++ b/service/models.py
@@ -547,7 +547,7 @@ class DeviceCode(db.Model):
         if not code_result:
             logger.debug(f"Device Code: {code_result} not found")
             raise InvalidDeviceCodeError(msg="device code not valid.")
-        if not code_result.status == "Entered":
+        if not code_result.status == "Authorized":
             logger.debug(f"Device Code: {code_result} not ready to be used")
             raise InvalidDeviceCodeError(msg="device code not ready.")
         # check for an expired code, plus a fudge factor for clock skew:

--- a/service/tests/basic_test.py
+++ b/service/tests/basic_test.py
@@ -222,7 +222,7 @@ def check_device_code_table(
     """
     print("Checking device_codes table")
     retrieved = models.DeviceCode.query.filter_by(user_code=user_code).first()
-    print(f"DEBUG: got device code object:: {retrieved}")
+    print(f"DEBUG: got device code object:: {retrieved.serialize}")
     if negative:
         assert retrieved is None
         return
@@ -1248,7 +1248,7 @@ def test_exchange_device_code(client):
             client_key=TEST_CLIENT_KEY,
             code=code,
             user_code=user_code,
-            status="Entered",
+            status="Authorized",
             verification_uri=verification_url,
             expiry_time=models.DeviceCode.compute_expiry(),
             access_token_ttl=models.DeviceCode.set_ttl(),
@@ -1268,7 +1268,7 @@ def test_exchange_device_code(client):
         raise Exception("Internal error saving device code. Please try again later.")
     # verify that it was added to the db correctly
     check_device_code_table(
-        TEST_CLIENT_ID, user_code, code, verification_url, "Entered"
+        TEST_CLIENT_ID, user_code, code, verification_url, "Authorized"
     )
 
     # call the tokens url with the device code


### PR DESCRIPTION
Closes #136

This updates the device code flow so the code is not token-ready until after the TTL form is submitted.