### PR TITLE
feat: WP-876 (1) login error; mention account reactivation, use constant

### DIFF
--- a/service/controllers.py
+++ b/service/controllers.py
@@ -33,6 +33,7 @@ from tapisservice.auth import validate_token, insecure_decode_jwt_to_claims
 
 from service import t
 from service.errors import InvalidPasswordError
+from service.login_messages import INVALID_USERNAME_PASSWORD_MESSAGE
 from service.helpers import handle_response_type, generate_authorization_code
 from service.session import logout, clear_orig_client_data, logout_from_webapp
 from service.models import (
@@ -849,7 +850,7 @@ class LoginResource(Resource):
                 tenant_id=tenant_id, username=username, password=password
             )
         except InvalidPasswordError:
-            context["error"] = "Invalid username/password combination."
+            context["error"] = INVALID_USERNAME_PASSWORD_MESSAGE
             return make_response(render_template("login.html", **context), 200, headers)
         # the username and password were accepted; set the session and redirect to the authorization page.
         # first, check if this is a multi_idp situation
@@ -1820,9 +1821,8 @@ def _handle_tokens_request(request, oidc=False):
             try:
                 check_username_password(tenant_id, username, password)
             except InvalidPasswordError:
-                msg = "Invalid username/password combination."
-                logger.debug(msg)
-                raise errors.ResourceError(msg)
+                logger.debug(INVALID_USERNAME_PASSWORD_MESSAGE)
+                raise errors.ResourceError(INVALID_USERNAME_PASSWORD_MESSAGE)
         elif grant_type == "authorization_code":
             # check the redirect uri -
             redirect_uri = data.get("redirect_uri")

--- a/service/ldap.py
+++ b/service/ldap.py
@@ -4,6 +4,7 @@ import json
 
 from service import tenants, MIGRATIONS_RUNNING
 from service.errors import InvalidPasswordError, InvalidTenantUserError
+from service.login_messages import INVALID_USERNAME_PASSWORD_MESSAGE
 from service.models import LdapOU, LdapUser, tenant_configs_cache
 
 from tapisservice.config import conf
@@ -493,7 +494,7 @@ def check_username_password(tenant_id, username, password):
         get_tenant_ldap_connection(tenant_id, bind_dn=bind_dn, bind_password=password)
     except LDAPBindError as e:
         logger.debug(f"got exception checking password: {e}; type(e): {type(e)}")
-        raise InvalidPasswordError("Invalid username/password combination.")
+        raise InvalidPasswordError(INVALID_USERNAME_PASSWORD_MESSAGE)
     # the bind above just checks that the username/password combination are in the underlying ldap; it does
     # not check that the user is in the user search filter for the tenant. for simplicty, we check that here
     try:

--- a/service/login_messages.py
+++ b/service/login_messages.py
@@ -1,0 +1,4 @@
+INVALID_USERNAME_PASSWORD_MESSAGE = (
+    "Invalid username/password combination or your account needs to be reactivated. "
+    "Click on Account Help below."
+)

--- a/service/login_messages.py
+++ b/service/login_messages.py
@@ -1,3 +1,3 @@
 INVALID_USERNAME_PASSWORD_MESSAGE = (
-    "Invalid username/password combination or your account needs reactivation. "
+    "Invalid username/password combination or your account needs reactivation."
 )

--- a/service/login_messages.py
+++ b/service/login_messages.py
@@ -1,4 +1,3 @@
 INVALID_USERNAME_PASSWORD_MESSAGE = (
-    "Invalid username/password combination or your account needs to be reactivated. "
-    "Click on Account Help below."
+    "Invalid username/password combination or your account needs reactivation. "
 )

--- a/service/tests/basic_test.py
+++ b/service/tests/basic_test.py
@@ -699,7 +699,7 @@ def test_password_grant_invalid_user_pass(client, init_db):
             content_type="application/json",
         )
         assert response.status_code == 400
-        assert "Invalid username/password combination." in response.json["message"]
+        assert "Invalid username/password combination or your account needs to be reactivated." in response.json["message"]
 
 
 def test_password_grant_invalid_uppercase_user(client, init_db):
@@ -721,7 +721,7 @@ def test_password_grant_invalid_uppercase_user(client, init_db):
             content_type="application/json",
         )
         assert response.status_code == 400
-        assert "Invalid username/password combination." in response.json["message"]
+        assert "Invalid username/password combination or your account needs to be reactivated." in response.json["message"]
 
 
 def test_password_grant_invalid_spaces_user(client, init_db):
@@ -743,7 +743,7 @@ def test_password_grant_invalid_spaces_user(client, init_db):
             content_type="application/json",
         )
         assert response.status_code == 400
-        assert "Invalid username/password combination." in response.json["message"]
+        assert "Invalid username/password combination or your account needs to be reactivated." in response.json["message"]
 
 
 def test_password_grant_valid(client, init_db):
@@ -890,7 +890,7 @@ def test_password_grant_user_not_in_tenant(client, init_db):
         headers={"X-Tapis-Local-Tenant": 'tacc'} # TEST_USERNAME should never be in the tacc tenant
     )
     assert response.status_code == 400
-    assert f"Invalid username/password combination" in response.json["message"]
+    assert "Invalid username/password combination or your account needs to be reactivated." in response.json["message"]
 
 
 def test_password_grant_user_in_group(client, init_db):

--- a/service/tests/basic_test.py
+++ b/service/tests/basic_test.py
@@ -11,6 +11,7 @@ from tapisservice.config import conf as tapisconf
 from service.models import tenant_configs_cache, DeviceCode
 from service.api import app
 from service import models, mfa
+from service.login_messages import INVALID_USERNAME_PASSWORD_MESSAGE
 
 
 # These tests are intended to be run locally.
@@ -699,7 +700,7 @@ def test_password_grant_invalid_user_pass(client, init_db):
             content_type="application/json",
         )
         assert response.status_code == 400
-        assert "Invalid username/password combination or your account needs to be reactivated." in response.json["message"]
+        assert INVALID_USERNAME_PASSWORD_MESSAGE in response.json["message"]
 
 
 def test_password_grant_invalid_uppercase_user(client, init_db):
@@ -721,7 +722,7 @@ def test_password_grant_invalid_uppercase_user(client, init_db):
             content_type="application/json",
         )
         assert response.status_code == 400
-        assert "Invalid username/password combination or your account needs to be reactivated." in response.json["message"]
+        assert INVALID_USERNAME_PASSWORD_MESSAGE in response.json["message"]
 
 
 def test_password_grant_invalid_spaces_user(client, init_db):
@@ -743,7 +744,7 @@ def test_password_grant_invalid_spaces_user(client, init_db):
             content_type="application/json",
         )
         assert response.status_code == 400
-        assert "Invalid username/password combination or your account needs to be reactivated." in response.json["message"]
+        assert INVALID_USERNAME_PASSWORD_MESSAGE in response.json["message"]
 
 
 def test_password_grant_valid(client, init_db):
@@ -890,7 +891,7 @@ def test_password_grant_user_not_in_tenant(client, init_db):
         headers={"X-Tapis-Local-Tenant": 'tacc'} # TEST_USERNAME should never be in the tacc tenant
     )
     assert response.status_code == 400
-    assert "Invalid username/password combination or your account needs to be reactivated." in response.json["message"]
+    assert INVALID_USERNAME_PASSWORD_MESSAGE in response.json["message"]
 
 
 def test_password_grant_user_in_group(client, init_db):


### PR DESCRIPTION
## Overview

Failed LDAP logins do not distinguish wrong password from inactive account, so stakeholder requested more comprehensive error message.

## Related

- [WP-876](https://tacc-main.atlassian.net/browse/WP-876) Goal 1

## Changes

- **added** shared `INVALID_USERNAME_PASSWORD_MESSAGE` in `service/login_messages.py`
- **updated** LDAP bind failure and login form error to use the expanded message
- **updated** password grant error response to match
- **updated** tests for the new message text

## Testing

1. Start the authenticator.
2. Open login form.
3. Enter invalid credentials.
4. Submit form.
5. Verify the error mentions account reactivation.
6. Verify the error mentions Account Help.
7. Call the password grant endpoint with invalid credentials.
8. Verify the API error message matches the login form text.

## UI

> [!WARNING]
> I can't actually test in my environment[^1], but it [should look like this](https://github.com/user-attachments/assets/631aaa99-b544-4a1b-957a-f65cd744fbab):

[^1]: I can't test in my macOS env because of known issue, tapis-project/authenticator#37.

<img width="412" height="475" alt="WP-876 Goal 1" src="https://github.com/user-attachments/assets/631aaa99-b544-4a1b-957a-f65cd744fbab" />