### PR TITLE
feat: WP-876 (2) DesignSafe Account Help link

### DIFF
--- a/service/templates/login.html
+++ b/service/templates/login.html
@@ -54,6 +54,10 @@
       <a href="mailto:support@tickets.txapcd.org" rel="nonreferrer" target="_blank" >
         For help, email support@tickets.txapcd.org
       </a>
+      {% elif tenant_id == 'designsafe' %}
+      <a href="https://designsafe-ci.org/user-guide/account-help/" rel="noreferrer" target="_blank">
+        Account Help
+      </a>
       {% else %}
       <a href="https://tacc.utexas.edu/about/help/" rel="noreferrer" target="_blank">
         Account Help

--- a/service/templates/select_idp.html
+++ b/service/templates/select_idp.html
@@ -32,6 +32,15 @@
      </div>
      <nav>
       <p>Having trouble?</p>
+      {% if tenant_id == 'designsafe' %}
+      <a
+        href="https://designsafe-ci.org/user-guide/account-help/"
+        rel="noreferrer"
+        target="_blank"
+      >
+        Account Help
+      </a>
+      {% else %}
       <a
         href="https://tacc.utexas.edu/about/help/"
         rel="noreferrer"
@@ -39,6 +48,7 @@
       >
         Account Help
       </a>
+      {% endif %}
     </nav>
 
  </form>


### PR DESCRIPTION
## Overview

DesignSafe users should open DesignSafe account-help documentation from the login flow; other tenants keep the existing TACC Account Help link.

## Related

- [WP-876](https://tacc-main.atlassian.net/browse/WP-876) Goal 2

## Changes

- **updated** `login.html` Account Help link when `tenant_id` is `designsafe`
- **updated** `select_idp.html` with the same DesignSafe branch (APCD mailto unchanged on login)

## Testing

1. Open the login page.
2. Locate the "Account Help" link.
3. Verify the link target is https://tacc.utexas.edu/about/help/.
4. <details><summary>Test login page as (if using) a DesignSafe tenant.</summary>
    
    I can not replicate DesignSafe tenant, and have trouble updating templates, so I did this:

    1. Add `- ./service/templates:/home/tapis/service/templates` to `docker-compose.yml` `volumes` for `authenticator`.
    2. Swap `designsafe` for `dev` in the template conditional.
    3. Refresh page.

    </details>
6. Locate the Account Help link.
7. Verify the link target has become https://tacc.utexas.edu/about/help/

## UI

https://github.com/user-attachments/assets/1a0677ee-8537-4997-ac77-c294d48d07e4