### PR TITLE
fix: WP-876 login form does not distinguish errors

### DIFF
--- a/service/controllers.py
+++ b/service/controllers.py
@@ -848,8 +848,8 @@ class LoginResource(Resource):
             check_username_password(
                 tenant_id=tenant_id, username=username, password=password
             )
-        except InvalidPasswordError:
-            context["error"] = "Invalid username/password combination."
+        except InvalidPasswordError as e:
+            context["error"] = str(e)
             return make_response(render_template("login.html", **context), 200, headers)
         # the username and password were accepted; set the session and redirect to the authorization page.
         # first, check if this is a multi_idp situation
@@ -1819,8 +1819,8 @@ def _handle_tokens_request(request, oidc=False):
                 )
             try:
                 check_username_password(tenant_id, username, password)
-            except InvalidPasswordError:
-                msg = "Invalid username/password combination."
+            except InvalidPasswordError as e:
+                msg = str(e)
                 logger.debug(msg)
                 raise errors.ResourceError(msg)
         elif grant_type == "authorization_code":


### PR DESCRIPTION
## Overview

The login error did not distinguish invalid username/password from account needing reactivation. I asked A.I. to solve that. It got confused (because I was also having it do #139). This ridiculous PR is the result.

<details><summary>A.I. Got Confused</summary>

## Overview

The login handler was overwriting every `InvalidPasswordError` with the generic invalid password string, hiding more specific messages LDAP already raises (for example username format rules).

## Related

- [WP-876](https://tacc-main.atlassian.net/browse/WP-876)
- related to https://github.com/tapis-project/authenticator/pull/139

## Changes

- **updated** login form POST to set `context["error"]` from `str(e)` on `InvalidPasswordError`
- **updated** password grant to propagate the same exception message

## Testing

1. Open the OAuth login form.
2. Enter a mixed-case username.
3. Enter a password.
4. Submit the form.
5. Verify the lowercase-only username message appears.
6. Verify the generic invalid password message does not appear.
7. Enter a valid-format lowercase username.
8. Enter an incorrect password.
9. Submit the form.
10. Verify the LDAP bind-failure message appears.

## UI

…