### PR TITLE
enhance(docker): mount templates volume so page refresh uses changed template

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
             # - ./config-local-uh.json:/home/tapis/config.json
             # - ./config-local-sdsc.json:/home/tapis/config.json
             - ./service.log:/home/tapis/service.log
+            - ./service/templates:/home/tapis/service/templates
         networks:
             - authenticator
         depends_on:


### PR DESCRIPTION
## Overview

When developing locally, template edits should be reflected on page after page refresh without needing to rebuild the image, so I mount the local `./service/templates` directory into the `authenticator` container.

> [!WARNING]
> If the committed `docker-compose.yml` is used on production, then decline this PR. _I can instead document this solution or offer it via a `docker-compose.local.py`._

## Changes

- **added** `./service/templates` volume mount to `authenticator` service in `docker-compose.yml`

## Testing

1. Start up the app.
2. Edit a file in `service/templates/`
3. Refresh the browser/page.
4. Changes appear without rebuilding image.

## UI

https://github.com/user-attachments/assets/e2b63383-d0dd-4cc1-a6a5-446595e91212